### PR TITLE
Remove imports. Remove postinstall compile

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,17 +1,15 @@
-import * as Cucumber from 'cucumber'
-import mockery from 'mockery'
-import path from 'path'
-import {fixedGetFeatures as getFeatures} from './getFeatures'
+const Cucumber = require('cucumber');
+const mockery = require('mockery');
+const path = require('path');
+const getFeatures = require('./getFeatures').fixedGetFeatures
 
-import {
-    wrapCommands,
-    executeHooksWithArgs,
-    executeSync,
-    executeAsync
-} from 'wdio-sync'
+const wrapCommands = require('wdio-sync').wrapCommands;
+const executeHooksWithArgs = require('wdio-sync').executeHooksWithArgs;
+const executeSync = require('wdio-sync').executeSync;
+const executeAsync = require('wdio-sync').executeAsync;
 
-import CucumberReporter from './reporter'
-import HookRunner from './hookRunner'
+const CucumberReporter = require('./reporter');
+const HookRunner = require('./hookRunner');
 
 const DEFAULT_TIMEOUT = 30000
 const DEFAULT_OPTS = {
@@ -174,5 +172,6 @@ adapterFactory.run = async function (cid, config, specs, capabilities) {
     return result
 }
 
-export default adapterFactory
-export { CucumberAdapter, adapterFactory }
+module.exports = {
+  CucumberAdapter, adapterFactory 
+} 

--- a/lib/getFeatures.js
+++ b/lib/getFeatures.js
@@ -1,8 +1,8 @@
-import { getFeatures } from 'cucumber/lib/cli/helpers'
-import { _ } from 'lodash'
-import path from 'path'
+const getFeatures = require('cucumber/lib/cli/helpers').getFeatures;
+const _ = require('lodash');
+const path = require('path');
 
-export async function fixedGetFeatures(options) {
+async function fixedGetFeatures(options) {
     let initialFeatures = await getFeatures(options),
         templates = _.compact(_.flattenDeep(findTemplates(initialFeatures))),
         featureWithTemplate,
@@ -126,4 +126,8 @@ function preparingScenariosForConcat(scenarios, options) {
         scenario.feature.lastStep = emptyLine - 1;
         return scenario;
     });
+}
+
+module.exports = {
+  fixedGetFeatures
 }

--- a/lib/hookRunner.js
+++ b/lib/hookRunner.js
@@ -1,4 +1,6 @@
-import { executeHooksWithArgs } from 'wdio-sync'
+const executeHooksWithArgs = require('wdio-sync').executeHooksWithArgs;
+
+
 const CUCUMBER_EVENTS = [
     'handleBeforeFeature', 'handleAfterFeature',
     'handleBeforeScenario', 'handleAfterScenario',
@@ -122,4 +124,4 @@ class HookRunner {
     }
 }
 
-export default HookRunner
+module.exports = HookRunner;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,4 +1,4 @@
-import { Status } from 'cucumber'
+const Status = require('cucumber').Status;
 
 const SETTLE_TIMEOUT = 5000
 const CUCUMBER_EVENTS = [
@@ -263,4 +263,5 @@ class CucumberReporter {
     }
 }
 
-export default CucumberReporter
+module.exports = CucumberReporter;
+

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "wdio-cucumber2fix-framework",
   "version": "0.0.8",
   "description": "A WebdriverIO plugin. Adapter for Cucumber2 testing framework.",
-  "main": "build/adapter.js",
+  "main": "lib/adapter.js",
   "scripts": {
-    "postinstall": "npm run compile",
     "build": "run-s compile",
     "clean": "rm -rf ./build ./coverage",
     "compile": "babel lib/ -d build/",


### PR DESCRIPTION
Imports changed to requires and _npm run compile_ removed  to prevent babel's unexpected imports in ._/build_ folder files.
